### PR TITLE
Use encoding instead of iconv and allow objects with url property.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js:
   - 0.8
   - 0.10
 before_script:
+	- npm update -g npm
   - npm install -g mocha

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - 0.8
   - 0.10
 before_script:
-	- npm update -g npm
+  - npm update -g npm
   - npm install -g mocha

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 0.8
   - 0.10
-before_script:
+before_install:
   - npm update -g npm
+before_script:
   - npm install -g mocha

--- a/README.md
+++ b/README.md
@@ -79,6 +79,35 @@ krawler
     });
 ```
 
+## Objects Example
+
+Instead of pure strings or an array of strings, one can also pass an object or
+an array of objects who each have the url as a property named 'url'. This enables you to access the properties of the url object later in the process. Example:
+
+```javascript
+var Krawler = require('krawler')
+
+var urls = [
+    { name: 'SomeSite', url: 'http://ondraplsek.cz' }
+];
+
+var krawler = new Krawler;
+
+krawler
+    .queue(urls)
+    .on('data', function($, url, response) {
+        // $ - cheerio instance
+        // url - the object which also contains the url property
+        // response - object from mikeal/request
+        // you can access object properties here, e.g. url.name = 'SomeSite'
+    })
+    .on('error', function(err, url) {
+        // there has been an 'error' on 'url'
+    })
+    .on('end', function() {
+        // all URLs has been fetched
+    });
+```
 
 ## Promises
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ Krawler.prototype.queue = function(urls) {
 
   if(urls === undefined || !urls.length) {
     if (!_.isObject(urls)) {
-      throw 'At least one URL must be specified.'
+      throw new Error('At least one URL must be specified.');
     };
   }
 
@@ -69,6 +69,14 @@ Krawler.prototype.queue = function(urls) {
   } else {
     urls = _.uniq(urls);
   }
+
+  _.each(urls, function(element) {
+    if (_.isObject(element)) {
+      if (!_.has(element, 'url')) {
+        throw new Error('Objects must contain a url property.');
+      };
+    };
+  });
 
   async.eachLimit(urls, self.options_.maxConnections, function(url, callback) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,9 @@ Krawler.prototype.queue = function(urls) {
   var self = this;
 
   if(urls === undefined || !urls.length) {
-    throw 'At least one URL must be specified.'
+    if (!_.isObject(urls)) {
+      throw 'At least one URL must be specified.'
+    };
   }
 
   if( !_.isArray(urls) ) {
@@ -70,7 +72,7 @@ Krawler.prototype.queue = function(urls) {
 
   async.eachLimit(urls, self.options_.maxConnections, function(url, callback) {
 
-    self.fetchUrl(url)
+    self.fetchUrl(_.isObject(url) ? url.url : url)
       .then(function(resolved) {
         self.emit('data', resolved.data, url, resolved.response);
       }, function(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var async = require('async'),
   events = require('events'),
   Q = require('q'),
   jschardet = require('jschardet'),
-  iconv = require('iconv-lite')
+  encoding = require('encoding')
 
 /**
  *
@@ -229,7 +229,7 @@ Krawler.prototype.convertToUTF8 = function(string) {
   if(detected && detected.encoding) {
 
     if(detected.encoding != 'utf-8' && detected.encoding != 'ascii') {
-      string = iconv.decode(string, detected.encoding);
+      string = encoding.convert(string, 'utf-8', detected.encoding).toString();
     } else if(typeof string != 'string') {
       string = string.toString();
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var async = require('async'),
   events = require('events'),
   Q = require('q'),
   jschardet = require('jschardet'),
-  Iconv = require('iconv').Iconv;
+  iconv = require('iconv-lite')
 
 /**
  *
@@ -227,10 +227,7 @@ Krawler.prototype.convertToUTF8 = function(string) {
   if(detected && detected.encoding) {
 
     if(detected.encoding != 'utf-8' && detected.encoding != 'ascii') {
-
-      var iconv = new Iconv(detected.encoding, 'UTF-8//TRANSLIT//IGNORE');
-      string = iconv.convert(string).toString();
-
+      string = iconv.decode(string, detected.encoding);
     } else if(typeof string != 'string') {
       string = string.toString();
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cheerio": "~0.15.0",
     "jschardet": "~1.1.0",
     "request": "~2.34.0",
-    "iconv-lite": "^0.2.11"
+    "encoding": "^0.1.7"
   },
   "devDependencies": {
     "chai": "~1.9.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "q": "~1.0.0",
     "cheerio": "~0.15.0",
     "jschardet": "~1.1.0",
-    "iconv": "~2.0.7",
     "request": "~2.34.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
       "url": "http://github.com/ondrs/node-krawler/blob/master/LICENSE.md"
     }
   ],
-  "repository":
-  {
+  "repository": {
     "type": "git",
     "url": "https://github.com/ondrs/node-krawler.git"
   },
@@ -42,7 +41,8 @@
     "q": "~1.0.0",
     "cheerio": "~0.15.0",
     "jschardet": "~1.1.0",
-    "request": "~2.34.0"
+    "request": "~2.34.0",
+    "iconv-lite": "^0.2.11"
   },
   "devDependencies": {
     "chai": "~1.9.0"

--- a/test/index.js
+++ b/test/index.js
@@ -182,5 +182,13 @@ describe('Krawler tests', function() {
 
   });
 
+  it('should fail if objects lacks a url property', function () {
+    var crawler = new Krawler;
+    var singleObject = {
+      name: 'foo'
+    }
+    expect(function() { crawler.queue(singleObject)}).to.throw(Error);
+  });
+
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -80,7 +80,7 @@ describe('Krawler tests', function() {
     crawler
       .queue(urls)
       .on('data', function(data, url, response) {
-        fetched.push(urls);
+        fetched.push(url);
       })
       .on('error', function(err, url) {
         done(err);
@@ -88,25 +88,27 @@ describe('Krawler tests', function() {
       .on('end', function() {
         expect(urls.length).to.be.equal(fetched.length);
         done();
-      })
+      });
 
   });
 
-  it('should fetch sing HTML page in queue', function(done) {
+  it('should fetch single HTML page in queue', function(done) {
 
     var crawler = new Krawler;
+    var resultUrl;
 
     crawler
-      .queue('https://www.google.cz')
+      .queue('http://www.google.cz')
       .on('data', function(data, url, response) {
-        expect(url).to.be.equal('https://www.google.cz');
+        resultUrl = url;
       })
       .on('error', function(err, url) {
         done(err);
       })
       .on('end', function() {
+        expect(resultUrl).to.equal('http://www.google.cz');
         done();
-      })
+      });
 
   });
 
@@ -123,6 +125,58 @@ describe('Krawler tests', function() {
         /** @type {cheerio} */
         var $ = result.data;
         expect($.html()).to.have.string('Jörg');
+        done();
+      });
+
+  });
+
+  it('should fetch single object with a url property', function(done) {
+
+    var crawler = new Krawler;
+    var singleObject = {
+      name: 'foo',
+      url: 'http://www.google.com'
+    }
+    var resultObject;
+
+    crawler
+      .queue(singleObject)
+      .on('data', function(data, url, response) {
+        resultObject = url;
+      })
+      .on('error', function(err, url) {
+        done(err);
+      })
+      .on('end', function() {
+        expect(resultObject.name).to.equal('foo');
+        done();
+      });
+
+  });
+
+  it('should fetch an array of objects with url properties', function(done) {
+
+    var urls = [{
+        name: 'foo',
+        url: 'http://www.google.com'
+      },
+      {
+        name: 'bar',
+        url: 'http://www.google.cz'
+      }],
+      fetched = [],
+      crawler = new Krawler;
+
+    crawler
+      .queue(urls)
+      .on('data', function(data, url, response) {
+        fetched.push(url);
+      })
+      .on('error', function(err, url) {
+        done(err);
+      })
+      .on('end', function() {
+        expect(urls.length).to.equal(fetched.length);
         done();
       });
 


### PR DESCRIPTION
Hello!

Nice little crawler project. :)

I couldn't use this because iconv wouldn't work (easily) on my Debian machine. I suggest changing the iconv dependency to encoding which uses iconv-lite which is both faster and has better compatibility. One can still use iconv with encoding if you feel like.

I also added the option to pass in an object with a url property instead of just a string. This allows the user to pass properties along with the url object that can then later be used when the data is returned. Useful if you need to do something different for each url that has been scraped. I also wrote tests and corrected another test that was for some reason always passed, although it ought to fail.

What do you think? :)
